### PR TITLE
Bowerの設定を修正

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,2 @@
 {
-  "directory": "blogs/static/bower_components"
 }

--- a/.bowerrc
+++ b/.bowerrc
@@ -1,2 +1,3 @@
 {
+  "directory": "blogs/static/bower_components"
 }

--- a/blog_system/settings.py
+++ b/blog_system/settings.py
@@ -96,7 +96,7 @@ STATIC_ROOT = os.path.join(PROJECT_ROOT, 'static')
 
 STATIC_URL = '/static/'
 
-BOWER_COMPONENTS_ROOT = os.path.join(PROJECT_ROOT, 'components')
+BOWER_COMPONENTS_ROOT = os.path.join(PROJECT_ROOT, 'components/')
 
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
@@ -141,5 +141,5 @@ USE_TZ = True
 
 BOWER_INSTALLED_APPS = (
     'jquery',
-    'Rin',
+    'Rin=git://github.com/raryosu/Rin#v3.3.7-2',
 )

--- a/blog_system/settings.py
+++ b/blog_system/settings.py
@@ -96,7 +96,7 @@ STATIC_ROOT = os.path.join(PROJECT_ROOT, 'static')
 
 STATIC_URL = '/static/'
 
-BOWER_COMPONENTS_ROOT = os.path.join(PROJECT_ROOT, 'components/')
+BOWER_COMPONENTS_ROOT = os.path.join(PROJECT_ROOT, 'components/blogs/static/')
 
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',

--- a/blogs/templates/blogs/base.html
+++ b/blogs/templates/blogs/base.html
@@ -7,7 +7,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>blog system</title>
-        <link rel="stylesheet" href="{% static 'css/components.css' %}">
+        <link rel="stylesheet" href="{% static 'rin/dist/css/bootstrap.min.css' %}">
         <script type="text/javascript" src="{% static 'jquery/dist/jquery.js' %}"></script>
         <style type="text/css">
             body{ padding-top: 80px; }


### PR DESCRIPTION
- .bowerrcの設定が邪魔をしているようだったので修正
- bowerのパスを修正したい場合は `BOWER_COMPONENTS_PATH` を修正すれば良さそうです
  - 例えば `BOWER_COMPONENTS_PATH=os.path.join(PROJECT_ROOT, 'components/blogs/static/')` など(未検証ですが…)
- BowerでRinを入れる場合の設定を修正
- テンプレート中の呼び出しを修正

どうやら，呼び込みがうまく言っていなかったのは， `BOWER_COMPONENTS_ROOT` の最後に `/` がなかったからのようです。